### PR TITLE
Improve server error handling

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -16,10 +16,6 @@
     // https://marketplace.visualstudio.com/items?itemName=EditorConfig.EditorConfig
     "EditorConfig.EditorConfig",
 
-    // Bracket Pair Colorizer 2
-    // https://marketplace.visualstudio.com/items?itemName=CoenraadS.bracket-pair-colorizer-2
-    "CoenraadS.bracket-pair-colorizer-2",
-
     // Gradle language support
     // https://marketplace.visualstudio.com/items?itemName=naco-siren.gradle-language
     "naco-siren.gradle-language",

--- a/server/src/main/java/umm3601/Server.java
+++ b/server/src/main/java/umm3601/Server.java
@@ -10,10 +10,10 @@ import com.mongodb.client.MongoDatabase;
 
 import io.javalin.Javalin;
 import io.javalin.core.util.RouteOverviewPlugin;
+import io.javalin.http.InternalServerErrorResponse;
 import umm3601.user.UserController;
 
 public class Server {
-
 
   public static void main(String[] args) {
 
@@ -68,9 +68,17 @@ public class Server {
     // of the HTTP request
     server.post("/api/users", userController::addNewUser);
 
+    // This catches any uncaught exceptions thrown in the server
+    // code and turns them into a 500 response ("Internal Server
+    // Error Response"). In general you'll like to *never* actually
+    // return this, as it's an instance of the server crashing in
+    // some way, and returning a 500 to your user is *super*
+    // unhelpful to them. In a production system you'd almost
+    // certainly want to use a logging library to log all errors
+    // caught here so you'd know about them and could try to address
+    // them.
     server.exception(Exception.class, (e, ctx) -> {
-      ctx.status(500);
-      ctx.json(e); // you probably want to remove this in production
+      throw new InternalServerErrorResponse(e.toString());
     });
   }
 }


### PR DESCRIPTION
This changes the `server.exception()` call to match the iteration template, which provides a more Javalin-y approach to handling the errors.

While I was here I also removed the bracket colorizer recommendation.