### PR TITLE
Update client code for S22

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -8,11 +8,13 @@
       "html"
     ],
     "cSpell.words": [
-        "Bson",
-        "CSCI",
-        "Javalin",
-        "sidenav",
-        "todos"
+      "Bson",
+      "compat",
+      "CSCI",
+      "Javalin",
+      "sidenav",
+      "todos",
+      "unsub"
     ],
     "angular.enable-experimental-ivy-prompt": false,
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -13,6 +13,7 @@
       "CSCI",
       "Javalin",
       "sidenav",
+      "testid",
       "todos",
       "unsub"
     ],

--- a/client/.browserslistrc
+++ b/client/.browserslistrc
@@ -14,4 +14,3 @@ last 2 Edge major versions
 last 2 Safari major versions
 last 2 iOS major versions
 Firefox ESR
-not IE 11 # Angular supports IE 11 only as an opt-in. To opt-in, remove the 'not' prefix on this line.

--- a/client/.eslintrc.json
+++ b/client/.eslintrc.json
@@ -45,6 +45,12 @@
               "_id"
             ]
           }
+        ],
+        "prefer-arrow/prefer-arrow-functions": [
+          "error",
+          {
+            "allowStandaloneDeclarations": true
+          }
         ]
       }
     },

--- a/client/cypress/integration/app.spec.ts
+++ b/client/cypress/integration/app.spec.ts
@@ -9,25 +9,39 @@ describe('App', () => {
     page.getAppTitle().should('contain', 'CSci 3601 Lab 4');
   });
 
-  it('The sidenav should open, navigate to "Users" and back to "Home"', () => {
-    // Before clicking on the button, the sidenav should be hidden
-    page.getSidenav()
-      .should('be.hidden');
+  describe('Sidenav', () => {
+    it('Should be invisible by default', () => {
+      // Before clicking on the button, the sidenav should be hidden
+      page.getSidenav()
+        .should('be.hidden')
+        .and('not.be.visible');
+    });
+
+    it('Should be openable by clicking the sidenav button', () => {
+      page.getSidenavButton().click();
+
+      page.getSidenav()
+        .should('not.be.hidden')
+        .and('be.visible');
+    });
+
+    it('Should have a working navigation to "Users"', () => {
+      page.getSidenavButton().click();
+      page.getSidenav();
+      // When we click the "Users" option in the side navbar…
+      page.getNavLink('Users').click();
+      // …then the URL of the current page should change to "…/users".
+      cy.url().should('match', /.*\/users$/);
+    });
 
 
-    page.getSidenavButton().click()
-      .should('be.visible');
-
-    page.getNavLink('Users').click();
-    cy.url().should('match', /\/users$/);
-    page.getSidenav()
-      .should('be.hidden');
-
-    page.getSidenavButton().click();
-    page.getNavLink('Home').click();
-    cy.url().should('match', /^https?:\/\/[^\/]+\/?$/);
-    page.getSidenav()
-      .should('be.hidden');
+    it('Should have a working navigation to "Home"', () => {
+      page.getSidenavButton().click();
+      // When we click the "Home" option in the side navbar…
+      page.getNavLink('Home').click();
+      // …then the URL of the current page should change to "…/".
+      cy.url().should('match', /.*\/$/);
+    });
   });
 
 });

--- a/client/cypress/integration/app.spec.ts
+++ b/client/cypress/integration/app.spec.ts
@@ -6,7 +6,7 @@ describe('App', () => {
   beforeEach(() => page.navigateTo());
 
   it('Should have the correct title', () => {
-    page.getAppTitle().should('contain', 'CSCI 3601 Iteration Template');
+    page.getAppTitle().should('contain', 'CSci 3601 Lab 4');
   });
 
   it('The sidenav should open, navigate to "Users" and back to "Home"', () => {

--- a/client/karma.conf.js
+++ b/client/karma.conf.js
@@ -31,9 +31,7 @@ module.exports = function (config) {
           branches: 80,
           functions: 80
         }
-      },
-      reports: ['html', 'lcovonly', 'text-summary'],
-      fixWebpackSourcePaths: true
+      }
     },
     reporters: ['progress', 'kjhtml'],
     port: 9876,

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -5,7 +5,11 @@ import { UserListComponent } from './users/user-list.component';
 import { UserProfileComponent } from './users/user-profile.component';
 import { AddUserComponent } from './users/add-user.component';
 
-
+// Note that the `users/new` route needs to come before
+// the `users/:id` route. If `users/:id` came first, it
+// would accidentally catch the requests to `users/new`;
+// the router would just think that the string "new"
+// is a user ID.
 const routes: Routes = [
   {path: '', component: HomeComponent},
   {path: 'users', component: UserListComponent},

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -5,14 +5,20 @@
 
       <!-- Side navigation links -->
 
-      <a mat-list-item routerLink="/" routerLinkActive="drawer-list-item-active"
-        #routerLinkActiveInstance="routerLinkActive" [attr.tabindex]="routerLinkActiveInstance.isActive ? 0 : -1"
-        [routerLinkActiveOptions]="{exact: true}" (click)="drawer.close()">
+      <a mat-list-item routerLink="/"
+        routerLinkActive="drawer-list-item-active"
+        #routerLinkActiveInstance="routerLinkActive"
+        [attr.tabindex]="routerLinkActiveInstance.isActive ? 0 : -1"
+        [routerLinkActiveOptions]="{exact: true}"
+        (click)="drawer.close()">
         <mat-icon matListIcon>home</mat-icon>
         Home
       </a>
 
-      <a mat-list-item routerLink="/users" routerLinkActive="drawer-list-item-active" (click)="drawer.close()">
+      <a mat-list-item
+        routerLink="/users"
+        routerLinkActive="drawer-list-item-active"
+        (click)="drawer.close()">
         <mat-icon matListIcon>people</mat-icon>
         Users
       </a>
@@ -22,7 +28,8 @@
 
   <mat-sidenav-content>
     <mat-toolbar color="primary">
-      <button type="button" aria-label="Toggle sidenav" mat-icon-button (click)="drawer.toggle()" onclick="this.blur()"
+      <button type="button" aria-label="Toggle sidenav" mat-icon-button
+        (click)="drawer.toggle()" onclick="this.blur()"
         class="sidenav-button">
         <mat-icon aria-label="Side nav toggle icon">menu</mat-icon>
       </button>

--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -2,7 +2,6 @@ import { TestBed, waitForAsync } from '@angular/core/testing';
 import { RouterTestingModule } from '@angular/router/testing';
 import { AppComponent } from './app.component';
 import { MatToolbarModule } from '@angular/material/toolbar';
-import { AppModule } from './app.module';
 import { MatIconModule } from '@angular/material/icon';
 import { MatSidenavModule } from '@angular/material/sidenav';
 import { MatCardModule } from '@angular/material/card';

--- a/client/src/app/app.component.spec.ts
+++ b/client/src/app/app.component.spec.ts
@@ -33,9 +33,9 @@ describe('AppComponent', () => {
     expect(app).toBeTruthy();
   });
 
-  it(`should have as title 'CSCI 3601 Iteration Template'`, () => {
+  it(`should have as title 'CSci 3601 Lab 4'`, () => {
     const fixture = TestBed.createComponent(AppComponent);
     const app = fixture.componentInstance;
-    expect(app.title).toEqual('CSCI 3601 Iteration Template');
+    expect(app.title).toEqual('CSci 3601 Lab 4');
   });
 });

--- a/client/src/app/app.component.ts
+++ b/client/src/app/app.component.ts
@@ -6,5 +6,5 @@ import { Component } from '@angular/core';
   styleUrls: ['./app.component.scss']
 })
 export class AppComponent {
-  title = 'CSCI 3601 Iteration Template';
+  title = 'CSci 3601 Lab 4';
 }

--- a/client/src/app/app.module.ts
+++ b/client/src/app/app.module.ts
@@ -1,37 +1,37 @@
-import { BrowserModule } from '@angular/platform-browser';
+import { LayoutModule } from '@angular/cdk/layout';
+import { HttpClientModule } from '@angular/common/http';
 import { NgModule } from '@angular/core';
+import { FlexLayoutModule } from '@angular/flex-layout';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
+
+import { MatButtonModule } from '@angular/material/button';
+import { MatCardModule } from '@angular/material/card';
+import { MatOptionModule } from '@angular/material/core';
+import { MatDividerModule } from '@angular/material/divider';
+import { MatExpansionModule } from '@angular/material/expansion';
+import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
+import { MatInputModule } from '@angular/material/input';
+import { MatListModule } from '@angular/material/list';
+import { MatMenuModule } from '@angular/material/menu';
+import { MatRadioModule } from '@angular/material/radio';
+import { MatSelectModule } from '@angular/material/select';
+import { MatSidenavModule } from '@angular/material/sidenav';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
+import { MatToolbarModule } from '@angular/material/toolbar';
+import { MatTooltipModule } from '@angular/material/tooltip';
+
+import { BrowserModule } from '@angular/platform-browser';
+import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
-import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { FormsModule, ReactiveFormsModule } from '@angular/forms';
-import { FlexLayoutModule } from '@angular/flex-layout';
-
-import {MatButtonModule} from '@angular/material/button';
-import { MatToolbarModule } from '@angular/material/toolbar';
-import { MatSidenavModule } from '@angular/material/sidenav';
-import { MatIconModule } from '@angular/material/icon';
-import { MatListModule } from '@angular/material/list';
-import { MatFormFieldModule } from '@angular/material/form-field';
-import { MatInputModule } from '@angular/material/input';
-import { MatCardModule } from '@angular/material/card';
-import { MatMenuModule } from '@angular/material/menu';
-import { MatExpansionModule } from '@angular/material/expansion';
-import { MatTooltipModule } from '@angular/material/tooltip';
-import { MatSelectModule } from '@angular/material/select';
-import { MatOptionModule } from '@angular/material/core';
-import {MatDividerModule} from '@angular/material/divider';
-import {MatRadioModule} from '@angular/material/radio';
-import {MatSnackBarModule} from '@angular/material/snack-bar';
-
-import { UserListComponent } from './users/user-list.component';
 import { HomeComponent } from './home/home.component';
-import { UserService } from './users/user.service';
-import { HttpClientModule } from '@angular/common/http';
-import { LayoutModule } from '@angular/cdk/layout';
-import { UserCardComponent } from './users/user-card.component';
-import { UserProfileComponent } from './users/user-profile.component';
 import { AddUserComponent } from './users/add-user.component';
+import { UserCardComponent } from './users/user-card.component';
+import { UserListComponent } from './users/user-list.component';
+import { UserProfileComponent } from './users/user-profile.component';
+import { UserService } from './users/user.service';
 
 const MATERIAL_MODULES: any[] = [
   MatListModule,

--- a/client/src/app/users/user-card.component.ts
+++ b/client/src/app/users/user-card.component.ts
@@ -9,8 +9,6 @@ import { User } from './user';
 export class UserCardComponent {
 
   @Input() user: User;
-  @Input() simple ? = false;
-
-  constructor() { }
+  @Input() simple?: boolean = false;
 
 }

--- a/client/src/app/users/user-list.component.html
+++ b/client/src/app/users/user-list.component.html
@@ -66,7 +66,7 @@
 
       <!-- Card grid view -->
       <div *ngSwitchCase="'card'" fxLayout="row wrap" fxLayoutGap="10px" class="user-cards-container">
-        <app-user-card simple="true" *ngFor="let user of filteredUsers" class="user-card" [user]="user" fxFlex="1 1 280px"></app-user-card>
+        <app-user-card [simple]="true" *ngFor="let user of filteredUsers" class="user-card" [user]="user" fxFlex="1 1 280px"></app-user-card>
       </div>
 
       <!-- List view -->
@@ -75,7 +75,7 @@
           <mat-nav-list class="user-nav-list">
             <h3 mat-subheader>Users</h3>
             <a mat-list-item *ngFor="let user of this.filteredUsers" [routerLink]="['/users', user._id]" class="user-list-item">
-              <img matListAvatar [src]="user.avatar" *ngIf="this.user.avatar">
+              <img matListAvatar [src]="user.avatar" alt="Avatar for {{user.name}}" *ngIf="this.user.avatar">
               <h3 matLine class="user-list-name"> {{user.name}} </h3>
               <p matLine class="user-list-role"> {{user.role}} </p>
             </a>

--- a/client/src/app/users/user-list.component.spec.ts
+++ b/client/src/app/users/user-list.component.spec.ts
@@ -113,10 +113,6 @@ describe('UserListComponent', () => {
  * to create mock objects (a service in this case) that be used for
  * testing. Here we set up the mock UserService (userServiceStub) so that
  * _always_ fails (throws an exception) when you request a set of users.
- *
- * So this doesn't really test anything meaningful in the context of our
- * code (I certainly wouldn't copy it), but it does illustrate some nice
- * testing tools. Hopefully it's useful as an example in that regard.
  */
 describe('Misbehaving User List', () => {
   let userServiceStub: {

--- a/client/src/app/users/user-list.component.spec.ts
+++ b/client/src/app/users/user-list.component.spec.ts
@@ -6,10 +6,12 @@ import { MatOptionModule } from '@angular/material/core';
 import { MatDividerModule } from '@angular/material/divider';
 import { MatExpansionModule } from '@angular/material/expansion';
 import { MatFormFieldModule } from '@angular/material/form-field';
+import { MatIconModule } from '@angular/material/icon';
 import { MatInputModule } from '@angular/material/input';
 import { MatListModule } from '@angular/material/list';
 import { MatRadioModule } from '@angular/material/radio';
 import { MatSelectModule } from '@angular/material/select';
+import { MatSnackBarModule } from '@angular/material/snack-bar';
 import { MatTooltipModule } from '@angular/material/tooltip';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { RouterTestingModule } from '@angular/router/testing';
@@ -19,7 +21,6 @@ import { User } from './user';
 import { UserCardComponent } from './user-card.component';
 import { UserListComponent } from './user-list.component';
 import { UserService } from './user.service';
-import { MatIconModule } from '@angular/material/icon';
 
 const COMMON_IMPORTS: any[] = [
   FormsModule,
@@ -34,6 +35,7 @@ const COMMON_IMPORTS: any[] = [
   MatListModule,
   MatDividerModule,
   MatRadioModule,
+  MatSnackBarModule,
   MatIconModule,
   BrowserAnimationsModule,
   RouterTestingModule,

--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -1,15 +1,25 @@
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnDestroy, OnInit } from '@angular/core';
+import { MatSnackBar } from '@angular/material/snack-bar';
+import { Subscription } from 'rxjs';
 import { User, UserRole } from './user';
 import { UserService } from './user.service';
-import { Subscription } from 'rxjs';
 
-@Component({
+/**
+ * A component that displays a list of users, either as a grid
+ * of cards or as a vertical list.
+ *
+ * The component supports local filtering by name and/or company,
+ * and remote filtering (i.e., filtering by the server) by
+ * role and/or age. These choices are fairly arbitrary here,
+ * but in "real" projects you want to think about where it
+ * makes the most sense to do the filtering.
+ */
+ @Component({
   selector: 'app-user-list-component',
   templateUrl: 'user-list.component.html',
   styleUrls: ['./user-list.component.scss'],
   providers: []
 })
-
 export class UserListComponent implements OnInit, OnDestroy  {
   // These are public so that tests can reference them (.spec.ts)
   public serverFilteredUsers: User[];
@@ -23,32 +33,58 @@ export class UserListComponent implements OnInit, OnDestroy  {
   getUsersSub: Subscription;
 
 
-  // Inject the UserService into this component.
-  // That's what happens in the following constructor.
-  //
-  // We can call upon the service for interacting
-  // with the server.
-
-  constructor(private userService: UserService) {
-
+  /**
+   * This constructor injects both an instance of `UserService`
+   * and an instance of `MatSnackBar` into this component.
+   *
+   * @param userService the `UserService` used to get users from the server
+   * @param snackBar the `MatSnackBar` used to display feedback
+   */
+  constructor(private userService: UserService, private snackBar: MatSnackBar) {
+    // Nothing here – everything is in the injection parameters.
   }
 
-  getUsersFromServer(): void {
+  /**
+   * Get the users from the server, filtered by the role and age specified
+   * in the GUI.
+   */
+  getUsersFromServer() {
+    // Effectively ignore any previous unresolved calls to get the
+    // users from the service (i.e., from the server).
     this.unsub();
+    // Request the users matching the currently specified role and age.
     this.getUsersSub = this.userService.getUsers({
       role: this.userRole,
       age: this.userAge
-    }).subscribe(returnedUsers => {
+    })
+    .subscribe(returnedUsers => {
+      // This inner function passed to `subscribe` will be called
+      // when the `Observable` returned by `getUsers()` has one
+      // or more values to return. `returnedUsers` will be the
+      // name for the array of `Users` we got back from the
+      // server.
       this.serverFilteredUsers = returnedUsers;
       this.updateFilter();
     }, err => {
-      console.log(err);
+      // If there was an error getting the users, log
+      // the problem and display a message.
+      console.error('We couldn\'t get the list of users; the server might be down');
+      this.snackBar.open(
+        'Problem contacting the server – try again',
+        'OK',
+        // The message will disappear after 3 seconds.
+        { duration: 3000 });
     });
   }
 
-  public updateFilter(): void {
+  /**
+   * Called when the filtering information is changed in the GUI so we can
+   * get an updated list of `filteredUsers`.
+   */
+   public updateFilter(): void {
     this.filteredUsers = this.userService.filterUsers(
-      this.serverFilteredUsers, { name: this.userName, company: this.userCompany });
+      this.serverFilteredUsers, { name: this.userName, company: this.userCompany }
+    );
   }
 
   /**
@@ -59,10 +95,18 @@ export class UserListComponent implements OnInit, OnDestroy  {
     this.getUsersFromServer();
   }
 
+  /**
+   * When this component is destroyed, we should unsubscribe to any
+   * outstanding requests.
+   */
   ngOnDestroy(): void {
     this.unsub();
   }
 
+  /**
+   * Unsubscribe to any outstanding requests if there are any
+   * since this component wont' be around to display the results.
+   */
   unsub(): void {
     if (this.getUsersSub) {
       this.getUsersSub.unsubscribe();

--- a/client/src/app/users/user.service.spec.ts
+++ b/client/src/app/users/user.service.spec.ts
@@ -59,120 +59,189 @@ describe('User service: ', () => {
     httpTestingController.verify();
   });
 
-  it('getUsers() calls api/users', () => {
-    // Assert that the users we get from this call to getUsers()
-    // should be our set of test users. Because we're subscribing
-    // to the result of getUsers(), this won't actually get
-    // checked until the mocked HTTP request 'returns' a response.
-    // This happens when we call req.flush(testUsers) a few lines
-    // down.
-    userService.getUsers().subscribe(
-      users => expect(users).toBe(testUsers)
-    );
+  describe('getUsers()', () => {
 
-    // Specify that (exactly) one request will be made to the specified URL.
-    const req = httpTestingController.expectOne(userService.userUrl);
-    // Check that the request made to that URL was a GET request.
-    expect(req.request.method).toEqual('GET');
-    // Specify the content of the response to that request. This
-    // triggers the subscribe above, which leads to that check
-    // actually being performed.
-    req.flush(testUsers);
+    it('calls `api/users` when `getUsers()` is called with no parameters', () => {
+      // Assert that the users we get from this call to getUsers()
+      // should be our set of test users. Because we're subscribing
+      // to the result of getUsers(), this won't actually get
+      // checked until the mocked HTTP request 'returns' a response.
+      // This happens when we call req.flush(testUsers) a few lines
+      // down.
+      userService.getUsers().subscribe(
+        users => expect(users).toBe(testUsers)
+      );
+
+      // Specify that (exactly) one request will be made to the specified URL.
+      const req = httpTestingController.expectOne(userService.userUrl);
+      // Check that the request made to that URL was a GET request.
+      expect(req.request.method).toEqual('GET');
+      // Check that the request had no query parameters.
+      expect(req.request.params.keys().length).toBe(0);
+      // Specify the content of the response to that request. This
+      // triggers the subscribe above, which leads to that check
+      // actually being performed.
+      req.flush(testUsers);
+    });
+
+    describe('Calling getUsers() with parameters correctly forms the HTTP request', () => {
+      /*
+       * We really don't care what `getUsers()` returns in the cases
+       * where the filtering is happening on the server. Since all the
+       * filtering is happening on the server, `getUsers()` is really
+       * just a "pass through" that returns whatever it receives, without
+       * any "post processing" or manipulation. So the tests in this
+       * `describe` block all confirm that the HTTP request is properly formed
+       * and sent out in the world, but don't _really_ care about
+       * what `getUsers()` returns as long as it's what the HTTP
+       * request returns.
+       *
+       * So in each of these tests, we'll keep it simple and have
+       * the (mocked) HTTP request return the entire list `testUsers`
+       * even though in "real life" we would expect the server to
+       * return return a filtered subset of the users.
+       */
+
+      it('correctly calls api/users with filter parameter \'admin\'', () => {
+        userService.getUsers({ role: 'admin' }).subscribe(
+          users => expect(users).toBe(testUsers)
+        );
+
+        // Specify that (exactly) one request will be made to the specified URL with the role parameter.
+        const req = httpTestingController.expectOne(
+          (request) => request.url.startsWith(userService.userUrl) && request.params.has('role')
+        );
+
+        // Check that the request made to that URL was a GET request.
+        expect(req.request.method).toEqual('GET');
+
+        // Check that the role parameter was 'admin'
+        expect(req.request.params.get('role')).toEqual('admin');
+
+        req.flush(testUsers);
+      });
+
+      it('correctly calls api/users with filter parameter \'age\'', () => {
+
+        userService.getUsers({ age: 25 }).subscribe(
+          users => expect(users).toBe(testUsers)
+        );
+
+        // Specify that (exactly) one request will be made to the specified URL with the role parameter.
+        const req = httpTestingController.expectOne(
+          (request) => request.url.startsWith(userService.userUrl) && request.params.has('age')
+        );
+
+        // Check that the request made to that URL was a GET request.
+        expect(req.request.method).toEqual('GET');
+
+        // Check that the role parameter was 'admin'
+        expect(req.request.params.get('age')).toEqual('25');
+
+        req.flush(testUsers);
+      });
+
+      it('correctly calls api/users with multiple filter parameters', () => {
+
+        userService.getUsers({ role: 'editor', company: 'IBM', age: 37 }).subscribe(
+          users => expect(users).toBe(testUsers)
+        );
+
+        // Specify that (exactly) one request will be made to the specified URL with the role parameter.
+        const req = httpTestingController.expectOne(
+          (request) => request.url.startsWith(userService.userUrl)
+            && request.params.has('role') && request.params.has('company') && request.params.has('age')
+        );
+
+        // Check that the request made to that URL was a GET request.
+        expect(req.request.method).toEqual('GET');
+
+        // Check that the role parameters are correct
+        expect(req.request.params.get('role')).toEqual('editor');
+        expect(req.request.params.get('company')).toEqual('IBM');
+        expect(req.request.params.get('age')).toEqual('37');
+
+        req.flush(testUsers);
+      });
+    });
   });
 
-  it('getUsers() calls api/users with filter parameter \'admin\'', () => {
+  describe('getUserByID()', () => {
+    it('calls api/users/id with the correct ID', () => {
+      // We're just picking a User "at random" from our little
+      // set of Users up at the top.
+      const targetUser: User = testUsers[1];
+      const targetId: string = targetUser._id;
 
-    userService.getUsers({ role: 'admin' }).subscribe(
-      users => expect(users).toBe(testUsers)
-    );
+      userService.getUserById(targetId).subscribe(
+        // This `expect` doesn't do a _whole_ lot.
+        // Since the `targetUser`
+        // is what the mock `HttpClient` returns in the
+        // `req.flush(targetUser)` line below, this
+        // really just confirms that `getUserById()`
+        // doesn't in some way modify the user it
+        // gets back from the server.
+        user => expect(user).toBe(targetUser)
+      );
 
-    // Specify that (exactly) one request will be made to the specified URL with the role parameter.
-    const req = httpTestingController.expectOne(
-      (request) => request.url.startsWith(userService.userUrl) && request.params.has('role')
-    );
+      const expectedUrl: string = userService.userUrl + '/' + targetId;
+      const req = httpTestingController.expectOne(expectedUrl);
+      expect(req.request.method).toEqual('GET');
 
-    // Check that the request made to that URL was a GET request.
-    expect(req.request.method).toEqual('GET');
-
-    // Check that the role parameter was 'admin'
-    expect(req.request.params.get('role')).toEqual('admin');
-
-    req.flush(testUsers);
+      req.flush(targetUser);
+    });
   });
 
-  it('getUsers() calls api/users with filter parameter \'age\'', () => {
+  describe('filterUsers()', () => {
+    /*
+     * Since `filterUsers` actually filters "locally" (in
+     * Angular instead of on the server), we do want to
+     * confirm that everything it returns has the desired
+     * properties. Since this doesn't make a call to the server,
+     * though, we don't have to use the mock HttpClient and
+     * all those complications.
+     */
+    it('filters by name', () => {
+      const userName = 'i';
+      const filteredUsers = userService.filterUsers(testUsers, { name: userName });
+      // There should be two users with an 'i' in their
+      // name: Chris and Jamie.
+      expect(filteredUsers.length).toBe(2);
+      // Every returned user's name should contain an 'i'.
+      filteredUsers.forEach(user => {
+        expect(user.name.indexOf(userName)).toBeGreaterThanOrEqual(0);
+      });
+    });
 
-    userService.getUsers({ age: 25 }).subscribe(
-      users => expect(users).toBe(testUsers)
-    );
+    it('filters by company', () => {
+      const userCompany = 'UMM';
+      const filteredUsers = userService.filterUsers(testUsers, { company: userCompany });
+      // There should be just one user that has UMM as their company.
+      expect(filteredUsers.length).toBe(1);
+      // Every returned user's company should contain 'UMM'.
+      filteredUsers.forEach(user => {
+        expect(user.company.indexOf(userCompany)).toBeGreaterThanOrEqual(0);
+      });
+    });
 
-    // Specify that (exactly) one request will be made to the specified URL with the role parameter.
-    const req = httpTestingController.expectOne(
-      (request) => request.url.startsWith(userService.userUrl) && request.params.has('age')
-    );
-
-    // Check that the request made to that URL was a GET request.
-    expect(req.request.method).toEqual('GET');
-
-    // Check that the role parameter was 'admin'
-    expect(req.request.params.get('age')).toEqual('25');
-
-    req.flush(testUsers);
-  });
-
-  it('getUsers() calls api/users with multiple filter parameters', () => {
-
-    userService.getUsers({ role: 'editor', company: 'IBM', age: 37 }).subscribe(
-      users => expect(users).toBe(testUsers)
-    );
-
-    // Specify that (exactly) one request will be made to the specified URL with the role parameter.
-    const req = httpTestingController.expectOne(
-      (request) => request.url.startsWith(userService.userUrl)
-        && request.params.has('role') && request.params.has('company') && request.params.has('age')
-    );
-
-    // Check that the request made to that URL was a GET request.
-    expect(req.request.method).toEqual('GET');
-
-    // Check that the role parameters are correct
-    expect(req.request.params.get('role')).toEqual('editor');
-    expect(req.request.params.get('company')).toEqual('IBM');
-    expect(req.request.params.get('age')).toEqual('37');
-
-    req.flush(testUsers);
-  });
-
-  it('getUserById() calls api/users/id', () => {
-    const targetUser: User = testUsers[1];
-    const targetId: string = targetUser._id;
-    userService.getUserById(targetId).subscribe(
-      user => expect(user).toBe(targetUser)
-    );
-
-    const expectedUrl: string = userService.userUrl + '/' + targetId;
-    const req = httpTestingController.expectOne(expectedUrl);
-    expect(req.request.method).toEqual('GET');
-    req.flush(targetUser);
-  });
-
-  it('filterUsers() filters by name', () => {
-    expect(testUsers.length).toBe(3);
-    const userName = 'a';
-    expect(userService.filterUsers(testUsers, { name: userName }).length).toBe(2);
-  });
-
-  it('filterUsers() filters by company', () => {
-    expect(testUsers.length).toBe(3);
-    const userCompany = 'UMM';
-    expect(userService.filterUsers(testUsers, { company: userCompany }).length).toBe(1);
-  });
-
-  it('filterUsers() filters by name and company', () => {
-    expect(testUsers.length).toBe(3);
-    const userCompany = 'UMM';
-    const userName = 'chris';
-    expect(userService.filterUsers(testUsers, { name: userName, company: userCompany }).length).toBe(1);
+    it('filters by name and company', () => {
+      // There's only one user (Chris) whose name
+      // contains an 'i' and whose company contains
+      // an 'M'. There are two whose name contains
+      // an 'i' and two whose company contains an
+      // an 'M', so this should test combined filtering.
+      const userName = 'i';
+      const userCompany = 'M';
+      const filters = { name: userName, company: userCompany };
+      const filteredUsers = userService.filterUsers(testUsers, filters);
+      // There should be just one user with these properties.
+      expect(filteredUsers.length).toBe(1);
+      // Every returned user should have _both_ these properties.
+      filteredUsers.forEach(user => {
+        expect(user.name.indexOf(userName)).toBeGreaterThanOrEqual(0);
+        expect(user.company.indexOf(userCompany)).toBeGreaterThanOrEqual(0);
+      });
+    });
   });
 
   it('addUser() posts to api/users', () => {

--- a/client/src/app/users/user.service.ts
+++ b/client/src/app/users/user.service.ts
@@ -5,14 +5,46 @@ import { environment } from '../../environments/environment';
 import { User, UserRole } from './user';
 import { map } from 'rxjs/operators';
 
+/**
+ * Service that provides the interface for getting information
+ * about `Users` from the server.
+ */
 @Injectable()
 export class UserService {
+  // The URL for the users part of the server API.
   readonly userUrl: string = environment.apiUrl + 'users';
 
+  // The private `HttpClient` is *injected* into the service
+  // by the Angular framework. This allows the system to create
+  // only one `HttpClient` and share that across all services
+  // that need it, and it allows us to inject a mock version
+  // of `HttpClient` in the unit tests so they don't have to
+  // make "real" HTTP calls to a server that might not exist or
+  // might not be currently running.
   constructor(private httpClient: HttpClient) {
   }
 
-  getUsers(filters?: { role?: UserRole; age?: number; company?: string }): Observable<User[]> {
+  /**
+   * Get all the users from the server, filtered by the information
+   * in the `filters` map.
+   *
+   * It would be more consistent with `UserListComponent` if this
+   * only supported filtering on age and role, and left company to
+   * just be in `filterUsers()` below. We've included it here, though,
+   * to provide some additional examples.
+   *
+   * @param filters a map that allows us to specify a target role, age,
+   *  or company to filter by, or any combination of those
+   * @returns an `Observable` of an array of `Users`. Wrapping the array
+   *  in an `Observable` means that other bits of of code can `subscribe` to
+   *  the result (the `Observable`) and get the results that come back
+   *  from the server after a possibly substantial delay (because we're
+   *  contacting a remote server over the Internet).
+   */
+   getUsers(filters?: { role?: UserRole; age?: number; company?: string }): Observable<User[]> {
+    // `HttpParams` is essentially just a map used to hold key-value
+    // pairs that are then encoded as "?key1=value1&key2=value2&…" in
+    // the URL when we make the call to `.get()` below.
     let httpParams: HttpParams = new HttpParams();
     if (filters) {
       if (filters.role) {
@@ -25,27 +57,45 @@ export class UserService {
         httpParams = httpParams.set('company', filters.company);
       }
     }
+    // Send the HTTP GET request with the given URL and parameters.
+    // That will return the desired `Observable<User[]>`.
     return this.httpClient.get<User[]>(this.userUrl, {
       params: httpParams,
     });
   }
 
-  getUserById(id: string): Observable<User> {
+  /**
+   * Get the `User` with the specified ID.
+   *
+   * @param id the ID of the desired user
+   * @returns an `Observable` containing the resulting user.
+   */
+   getUserById(id: string): Observable<User> {
     return this.httpClient.get<User>(this.userUrl + '/' + id);
   }
 
-  filterUsers(users: User[], filters: { name?: string; company?: string }): User[] {
-
+  /**
+   * A service method that filters an array of `User` using
+   * the specified filters.
+   *
+   * Note that the filters here support partial matches. Since the
+   * matching is done locally we can afford to repeatedly look for
+   * partial matches instead of waiting until we have a full string
+   * to match against.
+   *
+   * @param users the array of `Users` that we're filtering
+   * @param filters the map of key-value pairs used for the filtering
+   * @returns an array of `Users` matching the given filters
+   */
+   filterUsers(users: User[], filters: { name?: string; company?: string }): User[] {
     let filteredUsers = users;
 
-    // Filter by name
     if (filters.name) {
       filters.name = filters.name.toLowerCase();
 
       filteredUsers = filteredUsers.filter(user => user.name.toLowerCase().indexOf(filters.name) !== -1);
     }
 
-    // Filter by company
     if (filters.company) {
       filters.company = filters.company.toLowerCase();
 

--- a/client/src/index.html
+++ b/client/src/index.html
@@ -2,7 +2,7 @@
 <html lang="en">
 <head>
   <meta charset="utf-8">
-  <title>Iteration Template</title>
+  <title>UMM CSci Lab 4</title>
   <base href="/">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/x-icon" href="favicon.ico">

--- a/client/src/styles.scss
+++ b/client/src/styles.scss
@@ -103,9 +103,3 @@ body {
 .mat-flat-button {
   text-transform: uppercase;
 }
-
-// Special styling for the E2E test highlighter
-#BP_ELEMENT_HIGHLIGHT__ {
-  z-index: 100;
-  background-color: yellow !important;
-}

--- a/client/src/testing/user.service.mock.ts
+++ b/client/src/testing/user.service.mock.ts
@@ -7,6 +7,8 @@ import { UserService } from '../app/users/user.service';
  * A "mock" version of the `UserService` that can be used to test components
  * without having to create an actual service.
  */
+// It needs to be `Injectable` since that's how services are typically
+// provided to components.
 @Injectable()
 export class MockUserService extends UserService {
   static testUsers: User[] = [
@@ -44,7 +46,12 @@ export class MockUserService extends UserService {
   }
 
   getUsers(filters: { role?: UserRole; age?: number; company?: string }): Observable<User[]> {
-    // Just return the test users regardless of what filters are passed in
+    // Our goal here isn't to test (and thus rewrite) the service, so we'll
+    // keep it simple and just return the test users regardless of what
+    // filters are passed in.
+    //
+    // The `of()` function converts a regular object or value into an
+    // `Observable` of that object or value.
     return of(MockUserService.testUsers);
   }
 


### PR DESCRIPTION
Bring over some other changes (other than all the dependency changes in #34) from Lab 3 and the iteration template that seem to make sense here.

This includes:

* Fixing the titles to be Lab 4 instead of the iteration template
* Using the sidenav Cypress tests from Lab 3 since they're a lot nicer
* Bringing a bunch of comments (and some restructuring) forward from Lab 3

I'm pretty sure I've duplicated a few changes that are in #34, so we should merge that in first and then see how that affects this.