### PR TITLE
Spot-fix the writeup and JUnit tests

### DIFF
--- a/LABTASKS.md
+++ b/LABTASKS.md
@@ -87,7 +87,7 @@ person you're pairing with.
   - Write tests for the server actions for the feature you added. Run
     them to make sure they fail. Then write the server code that
     makes those tests pass.
-  - Write new integration (end-to-end) tests for the new views
+  - Write new end-to-end tests for the new views
     using Cypress. Run these to make sure they fail.
   - Write unit tests for the new Angular components you are adding
     using Karma. Run them to make sure they also fail. Then write the

--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ MongoDB server version: 3.4.24
 
 Type `exit` or `^D` to exit out of the `mongo` shell tool.
 
-> :warning: Far various reasons we're still running a fairly
+> :warning: For various reasons we're still running a fairly
 old version of Mongo in the lab (v3, when the current version
 is v5). This generally won't affect, but there are features that
 v3 doesn't support. If you're trying something you found online
@@ -177,7 +177,7 @@ You can explore the databases and collections here. You can click a record to vi
 
 ## Testing and Continuous Integration
 
-You have the same testing options as before, and you can test the
+You have the same testing options as before: you can test the
 client, or the server or both.
 
 ### Testing the client

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -392,7 +392,7 @@ public class UserControllerSpec {
   public void respondsAppropriateToAddingUserWithAgeOfZero() throws IOException {
     String testNewUser = "{"
       + "\"name\": \"Test User\","
-      + "\"age\": \"0\","
+      + "\"age\": 0,"
       + "\"company\": \"testers\","
       + "\"email\": \"test@example.com\","
       + "\"role\": \"viewer\""
@@ -410,7 +410,7 @@ public class UserControllerSpec {
   public void respondsAppropriateToAddingUserWithNegativeAge() throws IOException {
     String testNewUser = "{"
       + "\"name\": \"Test User\","
-      + "\"age\": \"-1\","
+      + "\"age\": -1,"
       + "\"company\": \"testers\","
       + "\"email\": \"test@example.com\","
       + "\"role\": \"viewer\""


### PR DESCRIPTION
This PR is a follow-up to #38. It does two main things:

1. Makes a few spot-fixes to the writeup, either for spelling or flow.
2. Fixes a few places in the tests where we were writing `age` as a
   string instead of a number.