### PR TITLE
37 rationalize our use of unsubscribe

### DIFF
--- a/client/src/app/users/add-user.component.ts
+++ b/client/src/app/users/add-user.component.ts
@@ -105,17 +105,23 @@ export class AddUserComponent implements OnInit {
 
 
   submitForm() {
-    this.userService.addUser(this.addUserForm.value).subscribe(newID => {
-      this.snackBar.open(
-        `Added user ${this.addUserForm.value.name}`,
-        null,
-        { duration: 2000 }
-      );
-      this.router.navigate(['/users/', newID]);
-    }, err => {
-      this.snackBar.open('Failed to add the user', 'OK', {
-        duration: 5000,
-      });
+    this.userService.addUser(this.addUserForm.value).subscribe({
+      next: (newID) => {
+        this.snackBar.open(
+          `Added user ${this.addUserForm.value.name}`,
+          null,
+          { duration: 2000 }
+        );
+        this.router.navigate(['/users/', newID]);
+      },
+      error: err => {
+        this.snackBar.open(
+          'Failed to add the user',
+          'OK',
+          { duration: 5000 }
+        );
+      },
+      // complete: () => console.log('Add user completes!')
     });
   }
 

--- a/client/src/app/users/user-list.component.ts
+++ b/client/src/app/users/user-list.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { MatSnackBar } from '@angular/material/snack-bar';
-import { Subscription } from 'rxjs';
+import { Subject, takeUntil } from 'rxjs';
 import { User, UserRole } from './user';
 import { UserService } from './user.service';
 
@@ -31,7 +31,8 @@ export class UserListComponent implements OnInit, OnDestroy  {
   public userRole: UserRole;
   public userCompany: string;
   public viewType: 'card' | 'list' = 'card';
-  getUsersSubscription: Subscription;
+
+  private ngUnsubscribe = new Subject<void>();
 
 
   /**
@@ -51,18 +52,16 @@ export class UserListComponent implements OnInit, OnDestroy  {
    * in the GUI.
    */
   getUsersFromServer(): void {
-    // Effectively ignore any previous unresolved calls to get the
-    // users from the service (i.e., from the server).
-    this.unsubscribeConditionally();
-    // A user-list-component has a getUsersSubscription (which is a subscription)
-    // that is paying attention to userService.getUsers (which is an Observable<User[]>)
+    // A user-list-component is paying attention to userService.getUsers
+    // (which is an Observable<User[]>)
     // (for more on Observable, see: https://reactivex.io/documentation/observable.html)
     // and we are specifically watching for role and age whenever the User[] gets updated
-    this.getUsersSubscription = this.userService.getUsers({
+    this.userService.getUsers({
       role: this.userRole,
       age: this.userAge
-    })
-    .subscribe({
+    }).pipe(
+      takeUntil(this.ngUnsubscribe)
+    ).subscribe({
       // Next time we see a change in the Observable<User[]>,
       // refer to that User[] as returnedUsers here and do the steps in the {}
       next: (returnedUsers) => {
@@ -81,7 +80,7 @@ export class UserListComponent implements OnInit, OnDestroy  {
         console.error('We couldn\'t get the list of users; the server might be down');
       },
       // Once the observable has completed successfully
-      complete: () => console.log('Users were filtered on the server') //this WAS console.info, but that wasn't allowed here
+      // complete: () => console.log('Users were filtered on the server')
     });
   }
 
@@ -106,22 +105,9 @@ export class UserListComponent implements OnInit, OnDestroy  {
    * When this component is destroyed, we should unsubscribe to any
    * outstanding requests.
    */
-  ngOnDestroy(): void {
-    // When we destroy the user-list-component, unsubscribe from that Observable<User[]>
-    // This unsubscribing action allows the Observable to stop emitting events
-    // if we were the only ones paying attention
-    // (i.e., if all of the followers stop following, no need to tell us)
-    this.unsubscribeConditionally();
-  }
-
-  /**
-   * Unsubscribe to any outstanding requests if there are any
-   * since this component wont' be around to display the results.
-   */
-  unsubscribeConditionally(): void {
-    if (this.getUsersSubscription) {
-      this.getUsersSubscription.unsubscribe();
-    }
+  ngOnDestroy() {
+    this.ngUnsubscribe.next();
+    this.ngUnsubscribe.complete();
   }
 
 }

--- a/client/src/app/users/user-profile.component.html
+++ b/client/src/app/users/user-profile.component.html
@@ -1,5 +1,7 @@
 <div class="flex-row">
-  <div class="flex-1" fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10">
-    <app-user-card [user]="this.user"></app-user-card>
+  <div class="flex-1" fxFlex.gt-sm="80" fxFlexOffset.gt-sm="10"
+    *ngIf="user; else loading">
+    <app-user-card [user]="user"></app-user-card>
   </div>
 </div>
+<ng-template #loading>Loading User Profile data...</ng-template>

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -49,25 +49,22 @@ describe('UserProfileComponent', () => {
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
-
-    expect(component.id).toEqual(expectedUser._id);
     expect(component.user).toEqual(expectedUser);
   });
 
   it('should navigate to correct user when the id parameter changes', () => {
+    console.log('In parameter changing test');
     let expectedUser: User = MockUserService.testUsers[0];
     // Setting this should cause anyone subscribing to the paramMap
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
-
-    expect(component.id).toEqual(expectedUser._id);
+    expect(component.user).toEqual(expectedUser);
 
     // Changing the paramMap should update the displayed user profile.
     expectedUser = MockUserService.testUsers[1];
     activatedRoute.setParamMap({ id: expectedUser._id });
-
-    expect(component.id).toEqual(expectedUser._id);
+    expect(component.user).toEqual(expectedUser);
   });
 
   it('should have `null` for the user for a bad ID', () => {
@@ -76,7 +73,6 @@ describe('UserProfileComponent', () => {
     // If the given ID doesn't map to a user, we expect the service
     // to return `null`, so we would expect the component's user
     // to also be `null`.
-    expect(component.id).toEqual('badID');
     expect(component.user).toBeNull();
   });
 });

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -55,7 +55,6 @@ describe('UserProfileComponent', () => {
   });
 
   it('should navigate to correct user when the id parameter changes', () => {
-    console.log('In parameter changing test');
     let expectedUser: User = MockUserService.testUsers[0];
     // Setting this should cause anyone subscribing to the paramMap
     // to update. Our `UserProfileComponent` subscribes to that, so

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -49,6 +49,12 @@ describe('UserProfileComponent', () => {
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
+    // There is neat stuff happening in ngOnInit, and to make that visible in the tests
+    // we trigger ngOnInit() so that our observables will all be up to date
+    // Since we manipulate the paramMap in our test (and don't do that for real in the code),
+    // we needed call to ngOnInit here to update the profile component and thus renew our subscription.
+    // This holds for all the subsequent calls to `component.ngOnInit()` as well.
+    component.ngOnInit();
     expect(component.user).toEqual(expectedUser);
   });
 
@@ -59,17 +65,20 @@ describe('UserProfileComponent', () => {
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
+    component.ngOnInit();
     expect(component.user).toEqual(expectedUser);
 
     // Changing the paramMap should update the displayed user profile.
     expectedUser = MockUserService.testUsers[1];
     activatedRoute.setParamMap({ id: expectedUser._id });
+    component.ngOnInit();
     expect(component.user).toEqual(expectedUser);
   });
 
   it('should have `null` for the user for a bad ID', () => {
     activatedRoute.setParamMap({ id: 'badID' });
 
+    component.ngOnInit();
     // If the given ID doesn't map to a user, we expect the service
     // to return `null`, so we would expect the component's user
     // to also be `null`.

--- a/client/src/app/users/user-profile.component.spec.ts
+++ b/client/src/app/users/user-profile.component.spec.ts
@@ -8,6 +8,7 @@ import { User } from './user';
 import { UserCardComponent } from './user-card.component';
 import { UserProfileComponent } from './user-profile.component';
 import { UserService } from './user.service';
+import { MatSnackBar, MatSnackBarModule } from '@angular/material/snack-bar';
 
 describe('UserProfileComponent', () => {
   let component: UserProfileComponent;
@@ -22,7 +23,8 @@ describe('UserProfileComponent', () => {
     TestBed.configureTestingModule({
       imports: [
         RouterTestingModule,
-        MatCardModule
+        MatCardModule,
+        MatSnackBarModule
       ],
       declarations: [UserProfileComponent, UserCardComponent],
       providers: [
@@ -49,12 +51,6 @@ describe('UserProfileComponent', () => {
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
-    // There is neat stuff happening in ngOnInit, and to make that visible in the tests
-    // we trigger ngOnInit() so that our observables will all be up to date
-    // Since we manipulate the paramMap in our test (and don't do that for real in the code),
-    // we needed call to ngOnInit here to update the profile component and thus renew our subscription.
-    // This holds for all the subsequent calls to `component.ngOnInit()` as well.
-    component.ngOnInit();
     expect(component.user).toEqual(expectedUser);
   });
 
@@ -65,20 +61,17 @@ describe('UserProfileComponent', () => {
     // to update. Our `UserProfileComponent` subscribes to that, so
     // it should update right away.
     activatedRoute.setParamMap({ id: expectedUser._id });
-    component.ngOnInit();
     expect(component.user).toEqual(expectedUser);
 
     // Changing the paramMap should update the displayed user profile.
     expectedUser = MockUserService.testUsers[1];
     activatedRoute.setParamMap({ id: expectedUser._id });
-    component.ngOnInit();
     expect(component.user).toEqual(expectedUser);
   });
 
   it('should have `null` for the user for a bad ID', () => {
     activatedRoute.setParamMap({ id: 'badID' });
 
-    component.ngOnInit();
     // If the given ID doesn't map to a user, we expect the service
     // to return `null`, so we would expect the component's user
     // to also be `null`.

--- a/client/src/app/users/user-profile.component.ts
+++ b/client/src/app/users/user-profile.component.ts
@@ -1,42 +1,78 @@
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute, ParamMap } from '@angular/router';
+import { MatSnackBar } from '@angular/material/snack-bar';
 import { User } from './user';
 import { UserService } from './user.service';
-import { first, map, switchMap } from 'rxjs/operators';
+import { Subject } from 'rxjs';
+import { map, switchMap, takeUntil } from 'rxjs/operators';
 
 @Component({
   selector: 'app-user-profile',
   templateUrl: './user-profile.component.html',
   styleUrls: ['./user-profile.component.scss']
 })
-export class UserProfileComponent implements OnInit {
-
+export class UserProfileComponent implements OnInit, OnDestroy {
   user: User;
 
-  constructor(private route: ActivatedRoute, private userService: UserService) { }
+  // This `Subject` will only ever emit one (empty) value when
+  // `ngOnDestroy()` is called, i.e., when this component is
+  // destroyed. That can be used ot tell any subscriptions to
+  // terminate, allowing the system to free up their resources (like memory).
+  private ngUnsubscribe = new Subject<void>();
+
+  constructor(private snackBar: MatSnackBar, private route: ActivatedRoute, private userService: UserService) { }
 
   ngOnInit(): void {
-    // The map and switchMap are each steps in the pipeline...
-    // the map step pays attention to ParamMap
-    // the result from the map step is the id string
-    // that gets used by the switchMap, which was expecting a string...
-    // it uses that string to get an Observable<User>
-    //
+    // The `map`, `switchMap`, and `takeUntil` are all RXJS operators, and
+    // each represents a step in the pipeline built using the RXJS `pipe`
+    // operator.
+    // The map step takes the `ParamMap` from the `ActivatedRoute`, which
+    // is typically the URL in the browser bar.
+    // The result from the map step is the `id` string for the requested
+    // `User`.
+    // That ID string gets passed (by `pipe`) to `switchMap`, which transforms
+    // it into an Observable<User>, i.e., all the (zero or one) `User`s
+    // that have that ID.
+    // The `takeUntil` operator allows this pipeline to continue to emit values
+    // until `this.ngUnsubscribe` emits a value, saying to shut the pipeline
+    // down and clean up any associated resources (like memory).
     this.route.paramMap.pipe(
-      // Hey! The paramMap changed... map the paramMap into the id
+      // Map the paramMap into the id
       map((paramMap: ParamMap) => paramMap.get('id')),
-      // maps the Observable<string> (i.e., the id) into the Observable<User>
-      // an observable... for each id that comes in, process and return an observable of all the results from that thing that cme in
+      // Maps the `id` string into the Observable<User>,
+      // which will emit zero or one values depending on whether there is a
+      // `User` with that ID.
       switchMap((id: string) => this.userService.getUserById(id)),
-      // We only ever want the first value from the paramMap `Observable`;
-      // limiting what we return here to that first value ensures that this
-      // pipeline terminates and the subscription is garbage collected.
-      first()
+      // Allow the pipeline to continue to emit values until `this.ngUnsubscribe`
+      // returns a value, which only happens when this component is destroyed.
+      // At that point we shut down the pipeline, allowed any
+      // associated resources (like memory) are cleaned up.
+      takeUntil(this.ngUnsubscribe)
     ).subscribe({
       next: user => this.user = user,
-      // This is terrible error handling; we should tell the user something.
-      error: err => console.log('Error getting a user for user profile' + err),
-      complete: () => console.log('We got a new user, and we are done!'),
-    }); // when something happens, update our user field
+      error: _err => {
+        this.snackBar.open('Problem loading the user – try again', 'OK', {
+          duration: 5000,
+        });
+      }
+      /*
+       * You can uncomment the line that starts with `complete` below to use that console message
+       * as a way of verifying that this subscription is completing.
+       * We removed it since we were not doing anything interesting on completion
+       * and didn't want to clutter the console log
+       */
+      // complete: () => console.log('We got a new user, and we are done!'),
+    });
+  }
+
+  ngOnDestroy() {
+    // When the component is destroyed, we'll emit an empty
+    // value as a way of saying that any active subscriptions should
+    // shut themselves down so the system can free up any associated
+    // resources, like memory.
+    this.ngUnsubscribe.next();
+    // Calling `complete()` says that this `Subject` is done and will
+    // never send any further values.
+    this.ngUnsubscribe.complete();
   }
 }

--- a/client/src/app/users/user-profile.component.ts
+++ b/client/src/app/users/user-profile.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute, ParamMap } from '@angular/router';
 import { User } from './user';
 import { UserService } from './user.service';
-import { map, switchMap } from 'rxjs/operators';
+import { first, map, switchMap } from 'rxjs/operators';
 
 @Component({
   selector: 'app-user-profile',
@@ -28,6 +28,10 @@ export class UserProfileComponent implements OnInit {
       // maps the Observable<string> (i.e., the id) into the Observable<User>
       // an observable... for each id that comes in, process and return an observable of all the results from that thing that cme in
       switchMap((id: string) => this.userService.getUserById(id)),
+      // We only ever want the first value from the paramMap `Observable`;
+      // limiting what we return here to that first value ensures that this
+      // pipeline terminates and the subscription is garbage collected.
+      first()
     ).subscribe({
       next: user => this.user = user,
       // This is terrible error handling; we should tell the user something.

--- a/client/src/testing/user.service.mock.ts
+++ b/client/src/testing/user.service.mock.ts
@@ -55,14 +55,17 @@ export class MockUserService extends UserService {
   }
 
   getUserById(id: string): Observable<User> {
-    // If the specified ID is for the first test user,
+    // If the specified ID is for one of the test users,
     // return that user, otherwise return `null` so
     // we can test illegal user requests.
     if (id === MockUserService.testUsers[0]._id) {
       return of(MockUserService.testUsers[0]);
+    } else if (id === MockUserService.testUsers[1]._id) {
+      return of(MockUserService.testUsers[1]);
+    } else if (id === MockUserService.testUsers[2]._id) {
+      return of(MockUserService.testUsers[2]);
     } else {
       return of(null);
     }
   }
-
 }


### PR DESCRIPTION
This PR focuses on making changes to rationalize our use of `unsubscribe()`... and it does so largely by removing any use of `unsubscribe()` after making changes that don't require its use.