### PR TITLE
Remove superflous caching of node

### DIFF
--- a/.github/workflows/e2e.yaml
+++ b/.github/workflows/e2e.yaml
@@ -16,14 +16,6 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
-    - name: Cache node modules
-      uses: actions/cache@v3
-      with:
-        path: ~/.npm
-        key: ${{ runner.os }}-node-${{ hashFiles('**/package-lock.json') }}
-        restore-keys: |
-          ${{ runner.os }}-node-
-
     - name: Cache Gradle artifacts (downloaded JARs, the wrapper, and any downloaded JDKs)
       uses: actions/cache@v3
       with:


### PR DESCRIPTION
As pointed out here: https://github.com/UMM-CSci-3601/3601-lab4-mongo/pull/55#discussion_r1104930422

we might not need this. It does seem to be taking an awfully long time to do e2e tests. Let's try removing it.