### PR TITLE
Group users by company

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -29,7 +29,8 @@
       "sortorder",
       "testid",
       "todos",
-      "unsub"
+      "unsub",
+      "VINCH"
     ],
     "angular.enable-experimental-ivy-prompt": false,
 }

--- a/client/cypress/e2e/company-list.cy.ts
+++ b/client/cypress/e2e/company-list.cy.ts
@@ -1,0 +1,36 @@
+import { CompanyListPage } from '../support/company-list.po';
+
+const page = new CompanyListPage();
+
+describe('Company list', () => {
+
+  before(() => {
+    cy.task('seed:database');
+  });
+
+  beforeEach(() => {
+    page.navigateTo();
+  });
+
+  it('Should have the correct title', () => {
+    page.getUserTitle().should('have.text', 'Companies');
+  });
+
+  // There are 10 users in the database, two of which work
+  // for OHMNET, so there are 9 different companies.
+  it('Should show 9 companies in the list', () => {
+    page.getCompanyCards().should('have.length', 9);
+  });
+
+  it('Should contain a company with the name "OHMNET"', () => {
+    page.getCompanyCardByName('OHMNET').should('exist');
+  });
+
+  it('Should contain a company with the name "OHMNET" and 2 users', () => {
+    page.getCompanyCardUserNames('OHMNET').should('have.length', 2);
+  });
+
+  it('Should contain a company with the name "VINCH" and 1 user', () => {
+    page.getCompanyCardUserNames('VINCH').should('have.length', 1);
+  });
+});

--- a/client/cypress/support/company-list.po.ts
+++ b/client/cypress/support/company-list.po.ts
@@ -1,0 +1,63 @@
+export class CompanyListPage {
+  private readonly baseUrl = '/companies';
+  private readonly pageTitle = '.company-list-title';
+  private readonly companyCardSelector = '.company-cards-container .company-card';
+  // private readonly userListItemsSelector = '.user-nav-list .user-list-item';
+  // private readonly profileButtonSelector = '[data-test=viewProfileButton]';
+  // private readonly radioButtonSelector = `[data-test=viewTypeRadio] mat-radio-button`;
+  // private readonly userRoleDropdownSelector = '[data-test=userRoleSelect]';
+  // private readonly dropdownOptionSelector = `mat-option`;
+  // private readonly addUserButtonSelector = '[data-test=addUserButton]';
+
+  navigateTo() {
+    return cy.visit(this.baseUrl);
+  }
+
+  /**
+   * Gets the title of the app when visiting the `/users` page.
+   *
+   * @returns the value of the element with the ID `.user-list-title`
+   */
+  getUserTitle() {
+    return cy.get(this.pageTitle);
+  }
+
+  /**
+   * Get all the `company-card` DOM elements.
+   *
+   * @returns an iterable (`Cypress.Chainable`) containing all
+   *   the `company-card` DOM elements.
+   */
+   getCompanyCards() {
+    return cy.get(this.companyCardSelector);
+  }
+
+  /**
+   * Get a specific `company-card` DOM element by its name
+   * (which is in the `_id`) field.
+   */
+  getCompanyCardByName(companyName: string) {
+    return cy
+      // Get all the company cards
+      .get(this.companyCardSelector)
+      // Look for a (sub)element with the company name
+      .contains(companyName)
+      // Return the containing company card element
+      .parents('.company-card');
+  }
+
+  /**
+   * Get the list of users for a given `company-card` DOM element
+   * by its name (which is in the `_id`) field.
+   */
+  getCompanyCardUserNames(companyName: string) {
+    // Get the company card by name, then find the user names
+    return this
+       // Get the `.company-card` element for the given
+       // company name
+      .getCompanyCardByName(companyName)
+      // Find all the `.company-card-user-name` elements
+      // within the company card
+      .find('.company-card-user-name');
+  }
+}

--- a/client/src/app/app-routing.module.ts
+++ b/client/src/app/app-routing.module.ts
@@ -4,6 +4,7 @@ import { HomeComponent } from './home/home.component';
 import { UserListComponent } from './users/user-list.component';
 import { UserProfileComponent } from './users/user-profile.component';
 import { AddUserComponent } from './users/add-user.component';
+import { CompanyListComponent } from './company-list/company-list.component';
 
 // Note that the 'users/new' route needs to come before 'users/:id'.
 // If 'users/:id' came first, it would accidentally catch requests to
@@ -12,7 +13,8 @@ const routes: Routes = [
   {path: '', component: HomeComponent, title: 'Home'},
   {path: 'users', component: UserListComponent, title: 'Users'},
   {path: 'users/new', component: AddUserComponent, title: 'Add User'},
-  {path: 'users/:id', component: UserProfileComponent, title: 'User Profile'}
+  {path: 'users/:id', component: UserProfileComponent, title: 'User Profile'},
+  {path: 'companies', component: CompanyListComponent, title: 'Companies'},
 ];
 
 @NgModule({

--- a/client/src/app/app.component.html
+++ b/client/src/app/app.component.html
@@ -18,6 +18,11 @@
         Users
       </a>
 
+      <a mat-list-item routerLink="/companies" routerLinkActive="drawer-list-item-active"
+      (click)="drawer.close()">
+        <mat-icon matListItemIcon>business</mat-icon>
+        Companies
+      </a>
     </mat-nav-list>
   </mat-sidenav>
 

--- a/client/src/app/company-card/company-card.component.html
+++ b/client/src/app/company-card/company-card.component.html
@@ -1,0 +1,17 @@
+@if (this.company) {
+<mat-card>
+  <mat-card-header>
+    <mat-card-title class="company-card-name">{{ this.company._id }}</mat-card-title>
+    <mat-card-subtitle class="company-card-employee-count">
+      ({{ this.company.count }} {{ (this.company.count === 1) ? 'employee' : 'employees' }})
+    </mat-card-subtitle>
+  </mat-card-header>
+  <mat-card-content>
+    <ul class="company-card-users">
+      @for (user of this.company.users; track user._id) {
+        <li><span class="company-card-user-name">{{ user.name }}</span></li>
+      }
+    </ul>
+  </mat-card-content>
+</mat-card>
+}

--- a/client/src/app/company-card/company-card.component.spec.ts
+++ b/client/src/app/company-card/company-card.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CompanyCardComponent } from './company-card.component';
+
+describe('CompanyCardComponent', () => {
+  let component: CompanyCardComponent;
+  let fixture: ComponentFixture<CompanyCardComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CompanyCardComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CompanyCardComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/company-card/company-card.component.ts
+++ b/client/src/app/company-card/company-card.component.ts
@@ -1,0 +1,15 @@
+import { Component, Input } from '@angular/core';
+import { Company } from '../company-list/company';
+import { MatCard, MatCardContent, MatCardHeader, MatCardSubtitle, MatCardTitle } from '@angular/material/card';
+import { MatList, MatListItem } from '@angular/material/list';
+
+@Component({
+  selector: 'app-company-card',
+  standalone: true,
+  imports: [MatCard, MatCardHeader, MatCardTitle, MatCardSubtitle, MatCardContent, MatList, MatListItem],
+  templateUrl: './company-card.component.html',
+  styleUrl: './company-card.component.scss'
+})
+export class CompanyCardComponent {
+  @Input() company: Company;
+}

--- a/client/src/app/company-list/company-list.component.html
+++ b/client/src/app/company-list/company-list.component.html
@@ -1,0 +1,16 @@
+<div class="flex-row">
+  <div class="flex-1">
+    <h1 class="company-list-title">Companies</h1>
+    <div class="flex-row">
+      @if (this.companies()) {
+        <div class="flex-1">
+          <div class="company-cards-container flex-row gap-8 flex-wrap">
+            @for (company of this.companies(); track company._id) {
+              <app-company-card class="company-card" [company]="company" ></app-company-card>
+            }
+          </div>
+        </div>
+      }
+    </div>
+  </div>
+</div>

--- a/client/src/app/company-list/company-list.component.spec.ts
+++ b/client/src/app/company-list/company-list.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { CompanyListComponent } from './company-list.component';
+
+describe('CompanyListComponent', () => {
+  let component: CompanyListComponent;
+  let fixture: ComponentFixture<CompanyListComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [CompanyListComponent]
+    })
+    .compileComponents();
+    
+    fixture = TestBed.createComponent(CompanyListComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/client/src/app/company-list/company-list.component.spec.ts
+++ b/client/src/app/company-list/company-list.component.spec.ts
@@ -1,17 +1,41 @@
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
+import { Observable, of } from 'rxjs';
+import { UserService } from '../users/user.service';
+import { Company } from './company';
 import { CompanyListComponent } from './company-list.component';
 
 describe('CompanyListComponent', () => {
   let component: CompanyListComponent;
   let fixture: ComponentFixture<CompanyListComponent>;
 
+  let userServiceStub: Partial<UserService>;
+
   beforeEach(async () => {
+    userServiceStub = {
+      getCompanies: (): Observable<Company[]> => {
+        const testCompanies: Company[] = [
+          {
+            _id: 'company1',
+            count: 1,
+            users: [{_id: 'user1', name: 'User 1'}]
+          },
+          {
+            _id: 'company2',
+            count: 2,
+            users: [{_id: 'user2', name: 'User 2'}, {_id: 'user3', name: 'User 3'}]
+          }
+        ];
+        return of(testCompanies);
+      }
+    }
+
     await TestBed.configureTestingModule({
-      imports: [CompanyListComponent]
+      imports: [CompanyListComponent],
+      providers: [ { provide: UserService, useValue: userServiceStub } ]
     })
     .compileComponents();
-    
+
     fixture = TestBed.createComponent(CompanyListComponent);
     component = fixture.componentInstance;
     fixture.detectChanges();

--- a/client/src/app/company-list/company-list.component.ts
+++ b/client/src/app/company-list/company-list.component.ts
@@ -1,0 +1,20 @@
+import { Component, Signal } from '@angular/core';
+import { toSignal } from '@angular/core/rxjs-interop';
+import { CompanyCardComponent } from '../company-card/company-card.component';
+import { UserService } from '../users/user.service';
+import { Company } from './company';
+
+@Component({
+  selector: 'app-company-list',
+  standalone: true,
+  imports: [CompanyCardComponent],
+  templateUrl: './company-list.component.html',
+  styleUrl: './company-list.component.scss'
+})
+export class CompanyListComponent {
+  companies: Signal<Company[]>;
+
+  constructor(private userService: UserService) {
+    this.companies = toSignal(this.userService.getCompanies());
+  }
+}

--- a/client/src/app/company-list/company.ts
+++ b/client/src/app/company-list/company.ts
@@ -1,0 +1,7 @@
+import { UserNameId } from './user-name-id';
+
+export interface Company {
+  _id: string;  // The name of the company
+  count: number; // The number of users in the company
+  users: UserNameId[]; // The users in the company
+}

--- a/client/src/app/company-list/user-name-id.ts
+++ b/client/src/app/company-list/user-name-id.ts
@@ -1,0 +1,4 @@
+export interface UserNameId {
+  _id: string;  // The id of this user
+  name: string; // The name of this user
+}

--- a/client/src/app/users/user.service.ts
+++ b/client/src/app/users/user.service.ts
@@ -4,6 +4,7 @@ import { Observable } from 'rxjs';
 import { environment } from '../../environments/environment';
 import { User, UserRole } from './user';
 import { map } from 'rxjs/operators';
+import { Company } from '../company-list/company';
 
 /**
  * Service that provides the interface for getting information
@@ -110,6 +111,10 @@ export class UserService {
     }
 
     return filteredUsers;
+  }
+
+  getCompanies(): Observable<Company[]> {
+    return this.httpClient.get<Company[]>(`${environment.apiUrl}usersByCompany`);
   }
 
   addUser(newUser: Partial<User>): Observable<string> {

--- a/server/src/main/java/umm3601/user/UserByCompany.java
+++ b/server/src/main/java/umm3601/user/UserByCompany.java
@@ -1,0 +1,12 @@
+package umm3601.user;
+
+import java.util.List;
+
+@SuppressWarnings("checkstyle:visibilitymodifier")
+public class UserByCompany {
+  // Ignore Checkstyle warning about the identifier name.
+  @SuppressWarnings("checkstyle:membername")
+  public String _id;
+  public int count;
+  public List<UserIdName> users;
+}

--- a/server/src/main/java/umm3601/user/UserController.java
+++ b/server/src/main/java/umm3601/user/UserController.java
@@ -198,8 +198,6 @@ public class UserController implements Controller {
       sortBy = "_id";
     }
     String sortOrder = Objects.requireNonNullElse(ctx.queryParam("sortOrder"), "asc");
-    System.err.println("sortBy: " + sortBy);
-    System.err.println("sortOrder: " + sortOrder);
     Bson sortingOrder = sortOrder.equals("desc") ?  Sorts.descending(sortBy) : Sorts.ascending(sortBy);
 
     // The `UserByCompany` class is a simple class that has fields for the company

--- a/server/src/main/java/umm3601/user/UserGroupResult.java
+++ b/server/src/main/java/umm3601/user/UserGroupResult.java
@@ -1,0 +1,9 @@
+package umm3601.user;
+
+import java.util.List;
+
+public class UserGroupResult {
+  public String _id;
+  public int count;
+  public List<UserIdName> users;
+}

--- a/server/src/main/java/umm3601/user/UserGroupResult.java
+++ b/server/src/main/java/umm3601/user/UserGroupResult.java
@@ -1,9 +1,0 @@
-package umm3601.user;
-
-import java.util.List;
-
-public class UserGroupResult {
-  public String _id;
-  public int count;
-  public List<UserIdName> users;
-}

--- a/server/src/main/java/umm3601/user/UserIdName.java
+++ b/server/src/main/java/umm3601/user/UserIdName.java
@@ -1,6 +1,8 @@
 package umm3601.user;
 
+@SuppressWarnings("checkstyle:visibilitymodifier")
 public class UserIdName {
+  @SuppressWarnings("checkstyle:membername")
   public String _id;
   public String name;
 }

--- a/server/src/main/java/umm3601/user/UserIdName.java
+++ b/server/src/main/java/umm3601/user/UserIdName.java
@@ -1,0 +1,6 @@
+package umm3601.user;
+
+public class UserIdName {
+  public String _id;
+  public String name;
+}

--- a/server/src/test/java/umm3601/user/UserControllerSpec.java
+++ b/server/src/test/java/umm3601/user/UserControllerSpec.java
@@ -1,14 +1,15 @@
 package umm3601.user;
 
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.argThat;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 import static com.mongodb.client.model.Filters.eq;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 import java.io.IOException;
 import java.security.NoSuchAlgorithmException;
@@ -19,23 +20,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 
-import com.fasterxml.jackson.core.JsonProcessingException;
-import com.fasterxml.jackson.databind.JsonMappingException;
-
-import com.mongodb.MongoClientSettings;
-import com.mongodb.ServerAddress;
-import com.mongodb.client.MongoClient;
-import com.mongodb.client.MongoClients;
-import com.mongodb.client.MongoCollection;
-import com.mongodb.client.MongoDatabase;
-
 import org.bson.Document;
 import org.bson.types.ObjectId;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-
 import org.mockito.ArgumentCaptor;
 import org.mockito.ArgumentMatcher;
 import org.mockito.Captor;
@@ -43,15 +33,24 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 
-import io.javalin.validation.BodyValidator;
-import io.javalin.validation.ValidationException;
-import io.javalin.validation.Validator;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonMappingException;
+import com.mongodb.MongoClientSettings;
+import com.mongodb.ServerAddress;
+import com.mongodb.client.MongoClient;
+import com.mongodb.client.MongoClients;
+import com.mongodb.client.MongoCollection;
+import com.mongodb.client.MongoDatabase;
+
 import io.javalin.Javalin;
 import io.javalin.http.BadRequestResponse;
 import io.javalin.http.Context;
 import io.javalin.http.HttpStatus;
 import io.javalin.http.NotFoundResponse;
 import io.javalin.json.JavalinJackson;
+import io.javalin.validation.BodyValidator;
+import io.javalin.validation.ValidationException;
+import io.javalin.validation.Validator;
 
 /**
  * Tests the logic of the UserController
@@ -115,8 +114,7 @@ class UserControllerSpec {
     mongoClient = MongoClients.create(
         MongoClientSettings.builder()
             .applyToClusterSettings(builder -> builder.hosts(Arrays.asList(new ServerAddress(mongoAddr))))
-            .build()
-    );
+            .build());
     db = mongoClient.getDatabase("test");
   }
 
@@ -128,7 +126,8 @@ class UserControllerSpec {
 
   @BeforeEach
   void setupEach() throws IOException {
-    // Reset our mock context and argument captor (declared with Mockito annotations @Mock and @Captor)
+    // Reset our mock context and argument captor (declared with Mockito annotations
+    // @Mock and @Captor)
     MockitoAnnotations.openMocks(this);
 
     // Setup database
@@ -197,15 +196,18 @@ class UserControllerSpec {
   @Test
   void canGetAllUsers() throws IOException {
     // When something asks the (mocked) context for the queryParamMap,
-    // it will return an empty map (since there are no query params in this case where we want all users)
+    // it will return an empty map (since there are no query params in this case
+    // where we want all users)
     when(ctx.queryParamMap()).thenReturn(Collections.emptyMap());
 
     // Now, go ahead and ask the userController to getUsers
     // (which will, indeed, ask the context for its queryParamMap)
     userController.getUsers(ctx);
 
-    // We are going to capture an argument to a function, and the type of that argument will be
-    // of type ArrayList<User> (we said so earlier using a Mockito annotation like this):
+    // We are going to capture an argument to a function, and the type of that
+    // argument will be
+    // of type ArrayList<User> (we said so earlier using a Mockito annotation like
+    // this):
     // @Captor
     // private ArgumentCaptor<ArrayList<User>> userArrayListCaptor;
     // We only want to declare that captor once and let the annotation
@@ -213,12 +215,15 @@ class UserControllerSpec {
     // We reset the values of our annotated declarations using the command
     // `MockitoAnnotations.openMocks(this);` in our @BeforeEach
 
-    // Specifically, we want to pay attention to the ArrayList<User> that is passed as input
-    // when ctx.json is called --- what is the argument that was passed? We capture it and can refer to it later
+    // Specifically, we want to pay attention to the ArrayList<User> that is passed
+    // as input
+    // when ctx.json is called --- what is the argument that was passed? We capture
+    // it and can refer to it later
     verify(ctx).json(userArrayListCaptor.capture());
     verify(ctx).status(HttpStatus.OK);
 
-    // Check that the database collection holds the same number of documents as the size of the captured List<User>
+    // Check that the database collection holds the same number of documents as the
+    // size of the captured List<User>
     assertEquals(db.getCollection("users").countDocuments(), userArrayListCaptor.getValue().size());
   }
 
@@ -229,7 +234,7 @@ class UserControllerSpec {
     queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {"37"}));
     when(ctx.queryParamMap()).thenReturn(queryParams);
     when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class))
-      .thenReturn(Validator.create(Integer.class, "37", UserController.AGE_KEY));
+        .thenReturn(Validator.create(Integer.class, "37", UserController.AGE_KEY));
 
     userController.getUsers(ctx);
 
@@ -241,13 +246,15 @@ class UserControllerSpec {
     }
   }
 
-  // We've included another approach for testing if everything behaves when we ask for users that are 37
+  // We've included another approach for testing if everything behaves when we ask
+  // for users that are 37
   @Test
   void canGetUsersWithAge37Redux() throws JsonMappingException, JsonProcessingException {
     // When the controller calls `ctx.queryParamMap`, return the expected map for an
     // "?age=37" query.
     when(ctx.queryParamMap()).thenReturn(Map.of(UserController.AGE_KEY, List.of("37")));
-    // When the controller calls `ctx.queryParamAsClass() to get the value associated with
+    // When the controller calls `ctx.queryParamAsClass() to get the value
+    // associated with
     // the "age" key, return an appropriate Validator.
     Validator<Integer> validator = Validator.create(Integer.class, "37", UserController.AGE_KEY);
     when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class)).thenReturn(validator);
@@ -255,10 +262,12 @@ class UserControllerSpec {
     // Call the method under test.
     userController.getUsers(ctx);
 
-    // Verify that `getUsers` included a call to `ctx.status(HttpStatus.OK)` at some point.
+    // Verify that `getUsers` included a call to `ctx.status(HttpStatus.OK)` at some
+    // point.
     verify(ctx).status(HttpStatus.OK);
 
-    // Instead of using the Captor like in many other tests, we will use an ArgumentMatcher
+    // Instead of using the Captor like in many other tests, we will use an
+    // ArgumentMatcher
     // Verify that `ctx.json()` is called with a `List` of `User`s.
     // Each of those `User`s should have age 37.
     verify(ctx).json(argThat(new ArgumentMatcher<List<User>>() {
@@ -283,7 +292,7 @@ class UserControllerSpec {
     queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {"bad"}));
     when(ctx.queryParamMap()).thenReturn(queryParams);
     when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class))
-      .thenReturn(Validator.create(Integer.class, "bad", UserController.AGE_KEY));
+        .thenReturn(Validator.create(Integer.class, "bad", UserController.AGE_KEY));
 
     // This should now throw a `ValidationException` because
     // our request has an age that can't be parsed to a number,
@@ -304,7 +313,7 @@ class UserControllerSpec {
     queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {"151"}));
     when(ctx.queryParamMap()).thenReturn(queryParams);
     when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class))
-      .thenReturn(Validator.create(Integer.class, "151", UserController.AGE_KEY));
+        .thenReturn(Validator.create(Integer.class, "151", UserController.AGE_KEY));
 
     // This should now throw a `ValidationException` because
     // our request has an age that is larger than 150, which isn't allowed,
@@ -314,7 +323,7 @@ class UserControllerSpec {
     });
   }
 
-/**
+  /**
    * Test that if the user sends a request with an illegal value in
    * the age field (i.e., too small of a number)
    * we get a reasonable error code back.
@@ -325,7 +334,7 @@ class UserControllerSpec {
     queryParams.put(UserController.AGE_KEY, Arrays.asList(new String[] {"-1"}));
     when(ctx.queryParamMap()).thenReturn(queryParams);
     when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class))
-      .thenReturn(Validator.create(Integer.class, "-1", UserController.AGE_KEY));
+        .thenReturn(Validator.create(Integer.class, "-1", UserController.AGE_KEY));
 
     // This should now throw a `ValidationException` because
     // our request has an age that is smaller than 0, which isn't allowed,
@@ -379,7 +388,7 @@ class UserControllerSpec {
     queryParams.put(UserController.ROLE_KEY, Arrays.asList(new String[] {"viewer"}));
     when(ctx.queryParamMap()).thenReturn(queryParams);
     when(ctx.queryParamAsClass(UserController.ROLE_KEY, String.class))
-      .thenReturn(Validator.create(String.class, "viewer", UserController.ROLE_KEY));
+        .thenReturn(Validator.create(String.class, "viewer", UserController.ROLE_KEY));
 
     userController.getUsers(ctx);
 
@@ -396,7 +405,7 @@ class UserControllerSpec {
     when(ctx.queryParamMap()).thenReturn(queryParams);
     when(ctx.queryParam(UserController.COMPANY_KEY)).thenReturn("OHMNET");
     when(ctx.queryParamAsClass(UserController.AGE_KEY, Integer.class))
-      .thenReturn(Validator.create(Integer.class, "37", UserController.AGE_KEY));
+        .thenReturn(Validator.create(Integer.class, "37", UserController.AGE_KEY));
 
     userController.getUsers(ctx);
 
@@ -445,6 +454,109 @@ class UserControllerSpec {
     assertEquals("The requested user was not found", exception.getMessage());
   }
 
+  @Captor
+  private ArgumentCaptor<ArrayList<UserByCompany>> userByCompanyListCaptor;
+
+  @Test
+  public void testGetUsersGroupedByCompany() {
+    when(ctx.queryParam("sortBy")).thenReturn("company");
+    when(ctx.queryParam("sortOrder")).thenReturn("asc");
+    userController.getUsersGroupedByCompany(ctx);
+
+    // Capture the argument to `ctx.json()`
+    verify(ctx).json(userByCompanyListCaptor.capture());
+
+    // Get the value that was passed to `ctx.json()`
+    ArrayList<UserByCompany> result = userByCompanyListCaptor.getValue();
+
+    // There are 3 companies in the test data, so we should have 3 entries in the
+    // result.
+    assertEquals(3, result.size());
+
+    // The companies should be in alphabetical order by company name,
+    // and with user counts of 1, 2, and 1, respectively.
+    UserByCompany ibm = result.get(0);
+    assertEquals("IBM", ibm._id);
+    assertEquals(1, ibm.count);
+    UserByCompany ohmnet = result.get(1);
+    assertEquals("OHMNET", ohmnet._id);
+    assertEquals(2, ohmnet.count);
+    UserByCompany umm = result.get(2);
+    assertEquals("UMM", umm._id);
+    assertEquals(1, umm.count);
+
+    // The users for OHMNET should be Jamie and Sam, although we don't
+    // know what order they'll be in.
+    assertEquals(2, ohmnet.users.size());
+    assertTrue(ohmnet.users.get(0).name.equals("Jamie") || ohmnet.users.get(0).name.equals("Sam"),
+        "First user should have name 'Jamie' or 'Sam'");
+    assertTrue(ohmnet.users.get(1).name.equals("Jamie") || ohmnet.users.get(1).name.equals("Sam"),
+        "Second user should have name 'Jamie' or 'Sam'");
+  }
+
+  @Test
+  public void testGetUsersGroupedByCompanyDescending() {
+    when(ctx.queryParam("sortBy")).thenReturn("company");
+    when(ctx.queryParam("sortOrder")).thenReturn("desc");
+    userController.getUsersGroupedByCompany(ctx);
+
+    // Capture the argument to `ctx.json()`
+    verify(ctx).json(userByCompanyListCaptor.capture());
+
+    // Get the value that was passed to `ctx.json()`
+    ArrayList<UserByCompany> result = userByCompanyListCaptor.getValue();
+
+    // There are 3 companies in the test data, so we should have 3 entries in the
+    // result.
+    assertEquals(3, result.size());
+
+    // The companies should be in reverse alphabetical order by company name,
+    // and with user counts of 1, 2, and 1, respectively.
+    UserByCompany umm = result.get(0);
+    assertEquals("UMM", umm._id);
+    assertEquals(1, umm.count);
+    UserByCompany ohmnet = result.get(1);
+    assertEquals("OHMNET", ohmnet._id);
+    assertEquals(2, ohmnet.count);
+    UserByCompany ibm = result.get(2);
+    assertEquals("IBM", ibm._id);
+    assertEquals(1, ibm.count);
+  }
+
+  @Test
+  public void testGetUsersGroupedByCompanyOrderedByCount() {
+    when(ctx.queryParam("sortBy")).thenReturn("count");
+    when(ctx.queryParam("sortOrder")).thenReturn("asc");
+    userController.getUsersGroupedByCompany(ctx);
+
+    // Capture the argument to `ctx.json()`
+    verify(ctx).json(userByCompanyListCaptor.capture());
+
+    // Get the value that was passed to `ctx.json()`
+    ArrayList<UserByCompany> result = userByCompanyListCaptor.getValue();
+
+    // There are 3 companies in the test data, so we should have 3 entries in the
+    // result.
+    assertEquals(3, result.size());
+
+    // The companies should be in order by user count, and with counts of 1, 1, and 2,
+    // respectively. We don't know which order "IBM" and "UMM" will be in, since they
+    // both have a count of 1. So we'll get them both and then swap them if necessary.
+    UserByCompany ibm = result.get(0);
+    UserByCompany umm = result.get(1);
+    if (ibm._id.equals("UMM")) {
+      umm = result.get(0);
+      ibm = result.get(1);
+    }
+    UserByCompany ohmnet = result.get(2);
+    assertEquals("IBM", ibm._id);
+    assertEquals(1, ibm.count);
+    assertEquals("UMM", umm._id);
+    assertEquals(1, umm.count);
+    assertEquals("OHMNET", ohmnet._id);
+    assertEquals(2, ohmnet.count);
+  }
+
   @Test
   void addUser() throws IOException {
     String testNewUser = """
@@ -457,7 +569,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     userController.addNewUser(ctx);
     verify(ctx).json(mapCaptor.capture());
@@ -465,11 +577,12 @@ class UserControllerSpec {
     // Our status should be 201, i.e., our new user was successfully created.
     verify(ctx).status(HttpStatus.CREATED);
 
-    //Verify that the user was added to the database with the correct ID
+    // Verify that the user was added to the database with the correct ID
     Document addedUser = db.getCollection("users")
-      .find(eq("_id", new ObjectId(mapCaptor.getValue().get("id")))).first();
+        .find(eq("_id", new ObjectId(mapCaptor.getValue().get("id")))).first();
 
-    // Successfully adding the user should return the newly generated, non-empty MongoDB ID for that user.
+    // Successfully adding the user should return the newly generated, non-empty
+    // MongoDB ID for that user.
     assertNotEquals("", addedUser.get("_id"));
     assertEquals("Test User", addedUser.get("name"));
     assertEquals(25, addedUser.get(UserController.AGE_KEY));
@@ -491,14 +604,16 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
     });
 
-    // Our status should be 400, because our request contained information that didn't validate.
-    // However, I'm not yet sure how to test the specifics about validation problems encountered.
+    // Our status should be 400, because our request contained information that
+    // didn't validate.
+    // However, I'm not yet sure how to test the specifics about validation problems
+    // encountered.
     // verify(ctx).status(HttpStatus.BAD_REQUEST);
   }
 
@@ -514,7 +629,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
@@ -533,7 +648,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
@@ -552,7 +667,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
@@ -570,7 +685,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
@@ -589,7 +704,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
@@ -608,7 +723,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
@@ -626,7 +741,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);
@@ -645,7 +760,7 @@ class UserControllerSpec {
         }
         """;
     when(ctx.bodyValidator(User.class))
-      .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
+        .then(value -> new BodyValidator<User>(testNewUser, User.class, javalinJackson));
 
     assertThrows(ValidationException.class, () -> {
       userController.addNewUser(ctx);


### PR DESCRIPTION
This adds a new `usersByCompany` endpoint which returns the users (just ID and name) grouped by company. It supports two modifiers: `sortBy` and `sortOrder`. `sortBy` can be either `company` or `count`, and `sortOrder` can be either `asc` or `desc`.

I had to create two new Java classes to capture the structure of these results. `UserGroupResult` (which should be renamed) holds the company (`_id`), the `count` (how many users work for that company), and `users` (a list of `UserIdName` objects). The `UserIdName` objects just contain the `_id` and `name` of a `User`.

GitHub CoPilot was a huge help here, both in helping generate the queries, but also in debugging some `IOException` errors that were the result of mismatches between the structures being generated by the queries and my Java classes.